### PR TITLE
provide default `content-type` header when it is not present

### DIFF
--- a/addon/-private/utils/json-helpers.js
+++ b/addon/-private/utils/json-helpers.js
@@ -23,7 +23,7 @@ export function isJsonString(str) {
  * @private
  */
 export async function parseJSON(response) {
-  const responseType = response.headers.get('content-type');
+  const responseType = response.headers.get('content-type') || 'Empty Content-Type';
   let error;
 
   if (!response.ok) {


### PR DESCRIPTION
Fixes https://github.com/expel-io/ember-ajax-fetch/issues/12

opted to use `text/xml` so that codepath is consistent with chrome when no `content-type` is provided.  