### PR TITLE
Add `raw` support

### DIFF
--- a/tests/unit/mixins/fetch-request-test.js
+++ b/tests/unit/mixins/fetch-request-test.js
@@ -322,6 +322,39 @@ module('Unit | Mixin | fetch-request', function(hooks) {
     assert.equal(options.contentType, defaultContentType);
   });
 
+  test('raw() response.post === options.data.post', function(assert) {
+    const service = FetchRequest.create();
+    const url = '/posts';
+    const title = 'Title';
+    const description = 'Some description.';
+    const contentType = 'application/json';
+    const customHeader = 'My custom header';
+    const options = {
+      data: {
+        post: { title, description }
+      }
+    };
+    const serverResponse = [
+      200,
+      { 'Content-Type': contentType,
+        'Custom-Header': customHeader },
+      JSON.stringify(options.data)
+    ];
+
+    this.server.get(url, () => serverResponse);
+
+    const rawPromise = service.raw(url, options);
+
+    return rawPromise.then(function({ response }) {
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('Custom-Header'), customHeader);
+      assert.equal(response.headers.get('Content-Type'), contentType);
+      return response.json();
+    }).then((json) => {
+      assert.deepEqual(json.post, options.data.post);
+    });
+  });
+
   test('post() response.post === options.data.post', function(assert) {
     const service = FetchRequest.create();
     const url = '/posts';


### PR DESCRIPTION
This add  a `raw` method to access the underlying fetch request.
Basically this PR is just a split of the existing `request` method.
First we make the fetch request.
Secondly we wrap the result to match ember-ajax.

Eg. You cannot access to the response headers without this method.