### PR TITLE
Adhoc: Fix yarnrc yaml file for updated registry settings

### DIFF
--- a/.yarnrc.yaml
+++ b/.yarnrc.yaml
@@ -1,1 +1,0 @@
-registry: "https://registry.yarnpkg.com"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+npmRegistryServer: "https://registry.yarnpkg.com"


### PR DESCRIPTION
Follows migration guide: https://yarnpkg.com/migration/guide#update-your-configuration-to-the-new-settings

I'm not sure if `.yaml` vs `.yml` matters as much but things were'nt working until I fixed the registry key name to be `npmRegistryServer`.