### PR TITLE
Return text response

### DIFF
--- a/addon/mixins/fetch-request.js
+++ b/addon/mixins/fetch-request.js
@@ -438,7 +438,7 @@ export default Mixin.create({
    */
   _handleResponse(response, requestOptions, url) {
     if (response.ok) {
-      return response.json;
+      return response.text || response.json;
     } else {
       throw this._createCorrectError(
         response,


### PR DESCRIPTION
The json helper supports both a json and text response: https://github.com/expel-io/ember-ajax-fetch/blob/57e546cd2446796ab75aa3ed04868c787d638941/addon/-private/utils/json-helpers.js#L73

But the text response is never returned. Ran into this while trying to parse an text/xml response which returned undefined.