### PR TITLE
Adhoc: Adds CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @expel-io/workbench-platform


### PR DESCRIPTION
### Description of Change

Appends workbench-platform to the list of default owners for all files in the repo. As a result of this change, all engineers in the Workbench Platform org will receive PR notifications for ember-ajax-fetch.

For context, ember-ajax-fetch is considered to be owned by all members of the Workbench Platform organization. In order to reflect this shared code ownership model, I created a Github team named [workbench-platform](https://github.com/orgs/expel-io/teams/workbench-platform). This team has been granted write access to ember-ajax-fetch.  

The workbench-platform team includes all engineers in the Workbench Platform organization. Engineering Managers have maintainer privileges so that they can update the team with their direct reports over time. 

Support requests for ember-ajax-fetch will continue to be captured as an issue in the Workbench Platform JIRA project (WBP).